### PR TITLE
Fix comment spelling in AppTest

### DIFF
--- a/src/test/java/cl/prezdev/crossword/AppTest.java
+++ b/src/test/java/cl/prezdev/crossword/AppTest.java
@@ -29,7 +29,7 @@ public class AppTest
     }
 
     /**
-     * Rigourous Test :-)
+     * Rigorous Test :-)
      */
     public void testApp()
     {


### PR DESCRIPTION
## Summary
- update the comment in `AppTest` to use "Rigorous"

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684110e9a95c83288029b361f92cf43c