### PR TITLE
Ensure config file streams close correctly

### DIFF
--- a/src/main/java/cl/prezdev/crossword/service/config/impl/JsonReadConfigFileImpl.java
+++ b/src/main/java/cl/prezdev/crossword/service/config/impl/JsonReadConfigFileImpl.java
@@ -12,14 +12,16 @@ import java.util.List;
 public class JsonReadConfigFileImpl implements ReadConfigFile {
     @Override
     public List<Word> loadWords(File file) throws FileNotFoundException {
-        InputStreamReader inputStreamReader = getInputStreamReader(file);
-        ConfigFile configFile = new Gson().fromJson(inputStreamReader, ConfigFile.class);
-
-        return new ConfigFileMapper().map(configFile);
+        try (FileInputStream inputStream = createFileInputStream(file);
+             InputStreamReader reader = new InputStreamReader(inputStream)) {
+            ConfigFile configFile = new Gson().fromJson(reader, ConfigFile.class);
+            return new ConfigFileMapper().map(configFile);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read config file", e);
+        }
     }
 
-    private InputStreamReader getInputStreamReader(File file) throws FileNotFoundException {
-        InputStream inputStream = new FileInputStream(file);
-        return new InputStreamReader(inputStream);
+    protected FileInputStream createFileInputStream(File file) throws FileNotFoundException {
+        return new FileInputStream(file);
     }
 }

--- a/src/test/java/cl/prezdev/crossword/service/config/impl/JsonReadConfigFileImplTest.java
+++ b/src/test/java/cl/prezdev/crossword/service/config/impl/JsonReadConfigFileImplTest.java
@@ -33,6 +33,7 @@ public class JsonReadConfigFileImplTest {
     @Test
     public void loadWords_closesStreams() throws Exception {
         File temp = File.createTempFile("config", ".json");
+        temp.deleteOnExit();
         Files.write(temp.toPath(), "{\"words\":[\"hello\"]}".getBytes(StandardCharsets.UTF_8));
 
         TrackingJsonReadConfigFileImpl reader = new TrackingJsonReadConfigFileImpl();

--- a/src/test/java/cl/prezdev/crossword/service/config/impl/JsonReadConfigFileImplTest.java
+++ b/src/test/java/cl/prezdev/crossword/service/config/impl/JsonReadConfigFileImplTest.java
@@ -1,0 +1,43 @@
+package cl.prezdev.crossword.service.config.impl;
+
+import cl.prezdev.crossword.service.config.impl.JsonReadConfigFileImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class JsonReadConfigFileImplTest {
+    private static class TrackingFileInputStream extends FileInputStream {
+        private boolean closed = false;
+        TrackingFileInputStream(File file) throws FileNotFoundException { super(file); }
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+        boolean isClosed() { return closed; }
+    }
+
+    private static class TrackingJsonReadConfigFileImpl extends JsonReadConfigFileImpl {
+        private TrackingFileInputStream stream;
+        @Override
+        protected FileInputStream createFileInputStream(File file) throws FileNotFoundException {
+            stream = new TrackingFileInputStream(file);
+            return stream;
+        }
+        boolean isStreamClosed() { return stream != null && stream.isClosed(); }
+    }
+
+    @Test
+    public void loadWords_closesStreams() throws Exception {
+        File temp = File.createTempFile("config", ".json");
+        Files.write(temp.toPath(), "{\"words\":[\"hello\"]}".getBytes(StandardCharsets.UTF_8));
+
+        TrackingJsonReadConfigFileImpl reader = new TrackingJsonReadConfigFileImpl();
+        reader.loadWords(temp);
+
+        Assert.assertTrue("Input stream should be closed after reading", reader.isStreamClosed());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `loadWords` with try-with-resources
- allow overriding file input stream creation for testing
- add unit test verifying that the reader closes its streams

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684111e364288328934636bbc45dd350